### PR TITLE
Fix two errors encountered at startup

### DIFF
--- a/pyxpose.py
+++ b/pyxpose.py
@@ -221,8 +221,8 @@ def process_gallery_description(input_file_gallery_description):
 
 if __name__ == '__main__':
     arguments = docopt(__doc__)
-    DATADIR = arguments['<gallery-path>']
-    TEMPLATE_DIR = arguments['--template']
+    DATADIR = os.path.abspath(arguments['<gallery-path>'])
+    TEMPLATE_DIR = os.path.abspath(arguments['--template'])
     try:
         os.chdir(TEMPLATE_DIR)
         TEMPLATE_DIR = os.getcwd()

--- a/pyxpose.py
+++ b/pyxpose.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 """pyxpose.
 
 Usage:


### PR DESCRIPTION
Without the shebang and the other fix, simply typing `pyxpose.py ../Example --template=./template` fails.